### PR TITLE
fix FuzzSdp with new version.

### DIFF
--- a/test/FuzzSdp.cpp
+++ b/test/FuzzSdp.cpp
@@ -7,18 +7,17 @@ int main(int argc, char** argv) {
   size_t length = 0;
   uint8_t* content = LoadFile(argv[1], &length);
 
-  Wu wu;
+  Wu* wu = nullptr;
+  const char* host = "127.0.0.1";
+  const char*  port = "5000";
+  int maxClients = 256;
 
-  WuConf conf;
-  conf.host = "127.0.0.1";
-  conf.port = "5000";
-
-  if (!WuInit(&wu, &conf)) {
+  if (!WuCreate(host, port, maxClients, &wu)) {
     return 0;
   }
 
   if (content) {
-    WuExchangeSDP(&wu, (const char*)content, length);
+    WuExchangeSDP(wu, (const char*)content, length);
   }
 
   return 0;

--- a/test/FuzzSdp.cpp
+++ b/test/FuzzSdp.cpp
@@ -10,7 +10,7 @@ int main(int argc, char** argv) {
   Wu* wu = nullptr;
   const char* host = "127.0.0.1";
   const char*  port = "5000";
-  int maxClients = 256;
+  int32_t maxClients = 256;
 
   if (!WuCreate(host, port, maxClients, &wu)) {
     return 0;


### PR DESCRIPTION
`FuzzSdp.cpp` is not compatible with current API, now it was fixed.
![image](https://github.com/seemk/WebUDP/assets/61657399/98f5a196-01d4-40be-8475-96704ff2f87b)
